### PR TITLE
Update with published citation details

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -2,24 +2,31 @@
 
 If you find this useful, please cite our work.
 
-There is a bioRxiv preprint available at: https://doi.org/10.1101/797506
-
-Genevieve Buckley, Gediminas Gervinskas, Cyntia Taveneau, Hari Venugopal,
-James C. Whisstock, Alex de Marco.
-**Automated cryo-lamella preparation for high-throughput in-situ structural biology**. *bioRxiv*, 2019.
+Genevieve Buckley, Gediminas Gervinskas, Cyntia Taveneau, Hariprasad Venugopal, James C. Whisstock, Alex de Marco,
+**Automated cryo-lamella preparation for high-throughput in-situ structural biology**,
+*Journal of Structural Biology*,
+Volume 210, Issue 2,
+2020
+https://doi.org/10.1016/j.jsb.2020.107488.
 
 BibTex:
 ```
-@article {Buckley797506,
-	author = {Buckley, Genevieve and Gervinskas, Gediminas and Taveneau, Cyntia and Venugopal, Hari and Whisstock, James C. and de Marco, Alex},
-	title = {Automated cryo-lamella preparation for high-throughput in-situ structural biology},
-	elocation-id = {797506},
-	year = {2019},
-	doi = {10.1101/797506},
-	publisher = {Cold Spring Harbor Laboratory},
-	abstract = {Cryo-transmission electron tomography (cryo-ET) in association with cryo-focused ion beam (cryo-FIB) milling enables structural biology studies to be performed directly within the cellular environment. Cryo-preserved cells are milled and a lamella with a thickness of 200-300 nm provides an electron transparent window suitable for cryo-ET imaging. Cryo-FIB milling is an effective method, but it is a tedious and time-consuming process, which typically results in ~10 lamellae per day. Here, we introduce an automated method to reproducibly prepare cryo-lamellae on a grid and reduce the amount of human supervision. We tested the routine on cryo-preserved Saccharomyces cerevisiae and demonstrate that this method allows an increased throughput, achieving a rate of 5 lamellae/hour without the need to supervise the FIB milling. We demonstrate that the quality of the lamellae is consistent throughout the preparation and their compatibility with cryo-ET analyses.},
-	URL = {https://www.biorxiv.org/content/early/2019/10/08/797506},
-	eprint = {https://www.biorxiv.org/content/early/2019/10/08/797506.full.pdf},
-	journal = {bioRxiv}
+@article{BUCKLEY2020107488,
+title = "Automated cryo-lamella preparation for high-throughput in-situ structural biology",
+journal = "Journal of Structural Biology",
+volume = "210",
+number = "2",
+pages = "107488",
+year = "2020",
+issn = "1047-8477",
+doi = "https://doi.org/10.1016/j.jsb.2020.107488",
+url = "http://www.sciencedirect.com/science/article/pii/S104784772030054X",
+author = "Genevieve Buckley and Gediminas Gervinskas and Cyntia Taveneau and Hariprasad Venugopal and James C. Whisstock and Alex {de Marco}",
+keywords = "Cryo-FIB, Cryo-lamella, Automation, cryo-EM, In situ structural biology",
+abstract = "Cryo-transmission electron tomography (cryo-ET) in association with cryo-focused ion beam (cryo-FIB) milling enables structural biology studies to be performed directly within the cellular environment. Cryo-preserved cells are milled and a lamella with a typical thickness of 200–300 nm provides an electron transparent window suitable for cryo-ET imaging. Cryo-FIB milling is an effective method, but it is a tedious and time-consuming process, which typically results in ~10 lamellae per day. Here, we introduce an automated method to reproducibly prepare cryo-lamellae on a grid and reduce the amount of human supervision. We tested the routine on cryo-preserved Saccharomyces cerevisiae, mammalian 293 T cells, and lysozyme protein crystals. Here we demonstrate that our method allows an increased throughput, achieving a rate of 5 lamellae/hour without the need to supervise the FIB milling. We demonstrate that the quality of the lamellae is consistent throughout the preparation and their compatibility with cryo-ET analyses."
 }
 ```
+
+You can download a PDF of our published work at: https://doi.org/10.1016/j.jsb.2020.107488
+
+There is also a bioRxiv preprint of this work available at: https://doi.org/10.1101/797506

--- a/README.md
+++ b/README.md
@@ -7,8 +7,15 @@ with focused ion beam milling.
 
 ## Citation
 If you find this useful, please cite our work.
-There is a bioRxiv preprint available at: https://doi.org/10.1101/797506
-See [CITATION](CITATION.md) for details.
+
+Genevieve Buckley, Gediminas Gervinskas, Cyntia Taveneau, Hariprasad Venugopal, James C. Whisstock, Alex de Marco,
+**Automated cryo-lamella preparation for high-throughput in-situ structural biology**,
+*Journal of Structural Biology*,
+Volume 210, Issue 2,
+2020
+https://doi.org/10.1016/j.jsb.2020.107488.
+
+See [CITATION](CITATION.md) for more details.
 
 ## Software license
 This software is released under the terms of the MIT license.


### PR DESCRIPTION
Originally we referred to our bioRxiv preprint in the README and CITATION files, this is now updated to refer to the published manuscript in the Journal of Structural Biology.