### PR TITLE
[FEAT} optionally use cleaning cross section or rectangle pattern

### DIFF
--- a/autolamella/milling.py
+++ b/autolamella/milling.py
@@ -112,14 +112,22 @@ def _milling_coords(microscope, stage_settings, my_lamella, pattern):
         if pattern == "upper" \
         else lamella_center_y - center_offset
 
-    # milling_roi = microscope.patterning.create_cleaning_cross_section(
-    milling_roi = microscope.patterning.create_rectangle(
-        lamella_center_x,
-        center_y,
-        stage_settings.get(f'lamella_width_{pattern}', stage_settings["lamella_width"]),
-        height,
-        milling_depth,
-    )
+    if stage_settings["use_cleaning_cross_section"]:
+        milling_roi = microscope.patterning.create_cleaning_cross_section(
+            lamella_center_x,
+            center_y,
+            stage_settings.get(f'lamella_width_{pattern}', stage_settings["lamella_width"]),
+            height,
+            milling_depth,
+        )
+    else:
+        milling_roi = microscope.patterning.create_rectangle(
+            lamella_center_x,
+            center_y,
+            stage_settings.get(f'lamella_width_{pattern}', stage_settings["lamella_width"]),
+            height,
+            milling_depth,
+        )
     if pattern == "upper":
         milling_roi.scan_direction = "TopToBottom"
     elif pattern == "lower":

--- a/protocol_chlanda.yml
+++ b/protocol_chlanda.yml
@@ -24,6 +24,7 @@ lamella: # Lamella parameters
   milling_depth: 0.8e-6 # In meters. Default milling depth.
   milling_current: 1000e-12    # In Amperes. Default milling current.
   patterning_mode: 'Parallel'
+  use_cleaning_cross_section: False
   # Protocol stages are milled in the order they appear here.
   # Stages may override the default parmeters above Eg: current, depth, etc.
   protocol_stages:

--- a/protocol_example.yml
+++ b/protocol_example.yml
@@ -24,6 +24,7 @@ lamella: # Lamella parameters
   milling_depth: 1e-6 # In meters. Default milling depth.
   milling_current: 1e-8 # In Amperes. Default milling current.
   patterning_mode: 'Serial'
+  use_cleaning_cross_section: True # use a cleaning cross section (true) or rectangle (false) pattern 
   # Protocol stages are milled in the order they appear here.
   # Stages may override the default parmeters above Eg: current, depth, etc.
   protocol_stages:


### PR DESCRIPTION
Added a flag to specify to use cleaning_cross_section or rectangle pattern for milling lamella.

See updated protocol_example.yml for usage:

Example, for a cleaning cross section.
```yaml
lamella:
    ...
    use_cleaning_cross_section: True 
```