### PR TITLE
[feat] Add support for non-fiducial based alignment area

### DIFF
--- a/autolamella/ui/qt/AutoLamellaUI.py
+++ b/autolamella/ui/qt/AutoLamellaUI.py
@@ -126,7 +126,7 @@ class Ui_MainWindow(object):
         self.scrollArea.setWidgetResizable(True)
         self.scrollArea.setObjectName("scrollArea")
         self.scrollAreaWidgetContents = QtWidgets.QWidget()
-        self.scrollAreaWidgetContents.setGeometry(QtCore.QRect(0, -72, 732, 710))
+        self.scrollAreaWidgetContents.setGeometry(QtCore.QRect(0, 0, 732, 710))
         self.scrollAreaWidgetContents.setObjectName("scrollAreaWidgetContents")
         self.gridLayout_4 = QtWidgets.QGridLayout(self.scrollAreaWidgetContents)
         self.gridLayout_4.setObjectName("gridLayout_4")
@@ -284,6 +284,9 @@ class Ui_MainWindow(object):
         self.doubleSpinBox_section_thickness = QtWidgets.QDoubleSpinBox(self.scrollAreaWidgetContents)
         self.doubleSpinBox_section_thickness.setObjectName("doubleSpinBox_section_thickness")
         self.gridLayout_4.addWidget(self.doubleSpinBox_section_thickness, 12, 1, 1, 1)
+        self.checkBox_align_use_fiducial = QtWidgets.QCheckBox(self.scrollAreaWidgetContents)
+        self.checkBox_align_use_fiducial.setObjectName("checkBox_align_use_fiducial")
+        self.gridLayout_4.addWidget(self.checkBox_align_use_fiducial, 16, 0, 1, 1)
         self.scrollArea.setWidget(self.scrollAreaWidgetContents)
         self.gridLayout_2.addWidget(self.scrollArea, 0, 0, 1, 2)
         self.tabWidget.addTab(self.tab_2, "")
@@ -365,7 +368,7 @@ class Ui_MainWindow(object):
         self.menubar.addAction(self.menuHelp.menuAction())
 
         self.retranslateUi(MainWindow)
-        self.tabWidget.setCurrentIndex(0)
+        self.tabWidget.setCurrentIndex(1)
         QtCore.QMetaObject.connectSlotsByName(MainWindow)
 
     def retranslateUi(self, MainWindow):
@@ -423,6 +426,7 @@ class Ui_MainWindow(object):
         self.checkBox_take_final_high_quality_reference.setText(_translate("MainWindow", "Acquire Final High Quality Image"))
         self.checkBox_align_at_milling_current.setText(_translate("MainWindow", "Align at Milling Current"))
         self.label_section_thickness.setText(_translate("MainWindow", "Section Thickness (um)"))
+        self.checkBox_align_use_fiducial.setText(_translate("MainWindow", "Use Fiducial"))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_2), _translate("MainWindow", "Protocol"))
         self.pushButton_yes.setText(_translate("MainWindow", "Yes"))
         self.label_title.setText(_translate("MainWindow", "AutoLamella"))

--- a/autolamella/ui/qt/AutoLamellaUI.ui
+++ b/autolamella/ui/qt/AutoLamellaUI.ui
@@ -36,7 +36,7 @@
     <item row="1" column="0" colspan="2">
      <widget class="QTabWidget" name="tabWidget">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="tab">
        <attribute name="title">
@@ -260,7 +260,7 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-72</y>
+             <y>0</y>
              <width>732</width>
              <height>710</height>
             </rect>
@@ -572,6 +572,13 @@
             </item>
             <item row="12" column="1">
              <widget class="QDoubleSpinBox" name="doubleSpinBox_section_thickness"/>
+            </item>
+            <item row="16" column="0">
+             <widget class="QCheckBox" name="checkBox_align_use_fiducial">
+              <property name="text">
+               <string>Use Fiducial</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </widget>

--- a/autolamella/workflows/core.py
+++ b/autolamella/workflows/core.py
@@ -58,8 +58,24 @@ from fibsem import config as fcfg
 from autolamella.workflows import actions
 from autolamella.workflows.ui import (set_images_ui, update_status_ui, 
                                       update_detection_ui, update_milling_ui, 
-                                      ask_user)
+                                      ask_user, update_alignment_area_ui)
 
+
+# DEFAULTS, TODO: move to a configuration file
+DEFAULT_ALIGNMENT_AREA = {"left": 0.25, "top": 0.25, "width": 0.5, "height": 0.5}
+DEFAULT_FIDUCIAL_PROTOCOL = {
+    "height": 10.e-6,
+    "width": 1.e-6,
+    "depth": 1.0e-6,
+    "rotation": 45,
+    "milling_current": 2.0e-9,
+    "preset": "30 keV; 20 nA", # TESCAN only
+    "application_file": "Si",
+    "passes": None,
+    "hfw": 80.e-6,
+    "type": "Fiducial",
+    }
+# TODO: complete the rest of the patterns
 
 # CORE WORKFLOW STEPS
 def log_status_message(lamella: Lamella, step: str):
@@ -473,6 +489,8 @@ def setup_lamella(
     settings.image.path = lamella.path
     method = settings.protocol["options"].get("method", "autolamella-waffle")
 
+    if "fiducial" not in settings.protocol["milling"]:
+        settings.protocol["milling"]["fiducial"] = DEFAULT_FIDUCIAL_PROTOCOL
 
     log_status_message(lamella, "ALIGN_LAMELLA")
     update_status_ui(parent_ui, f"{lamella.info} Aligning Lamella...")
@@ -540,15 +558,16 @@ def setup_lamella(
             stages += microexpansion_stage
 
     # fiducial
-    protocol = lamella.protocol if "fiducial" in lamella.protocol else settings.protocol["milling"]
-    FIDUCIAL_X_OFFSET = 25e-6
-    if method == "autolamella-liftout":
-        FIDUCIAL_X_OFFSET *= -1
-    fiducial_position = Point.from_dict(protocol["fiducial"].get("point", {"x": FIDUCIAL_X_OFFSET, "y": 0}))
-    fiducial_stage = patterning.get_milling_stages("fiducial", protocol, fiducial_position)
+    if use_fiducial:= settings.protocol["options"].get("use_fiducial", True):
+        protocol = lamella.protocol if "fiducial" in lamella.protocol else settings.protocol["milling"]
+        
+        FIDUCIAL_X_OFFSET = 25e-6
+        if method == "autolamella-liftout":
+            FIDUCIAL_X_OFFSET *= -1
+        
+        fiducial_position = Point.from_dict(protocol["fiducial"].get("point", {"x": FIDUCIAL_X_OFFSET, "y": 0}))
+        fiducial_stage = patterning.get_milling_stages("fiducial", protocol, fiducial_position)
 
-    use_fiducial = settings.protocol["options"].get("use_fiducial", True)
-    if use_fiducial:
         stages += fiducial_stage
     
     validate_position = True if method != "autolamella-on-grid" else validate
@@ -557,11 +576,10 @@ def setup_lamella(
             msg=f"Confirm the positions for the {lamella._petname} milling. Press Continue to Confirm.",
             validate=validate_position, # always validate non on-grid for now
             milling_enabled=False)
-       
-    from pprint import pprint
-    print("-"*80) 
-    pprint(stages)
-    print("-"*80)
+    
+    # TODO: can I remove this now...d
+    for stage in stages:
+        logging.info(f"{stage.name}: {stage}") 
 
     # lamella
     n_lamella = len(lamella_stages)
@@ -594,39 +612,49 @@ def setup_lamella(
     #     lamella.protocol[_feature_name]["point"] = stages[n_lamella].pattern.point.to_dict()
 
     # fiducial
-    # save fiducial information
-    n_fiducial = len(fiducial_stage)
     if use_fiducial:
+        n_fiducial = len(fiducial_stage)
         fiducial_stage = deepcopy(stages[-n_fiducial:])
 
-    fiducial_stage = fiducial_stage[0] # always single stage
-    lamella.protocol["fiducial"] = deepcopy(patterning.get_protocol_from_stages(fiducial_stage))
-    lamella.protocol["fiducial"]["point"] = fiducial_stage.pattern.point.to_dict()
-    lamella.fiducial_area, _  = _calculate_fiducial_area_v2(ib_image, 
-        deepcopy(fiducial_stage.pattern.point), 
-        lamella.protocol["fiducial"]["stages"][0]["height"])
-    alignment_hfw = fiducial_stage.milling.hfw
+        # save fiducial information
+        fiducial_stage = fiducial_stage[0] # always single stage
+        lamella.protocol["fiducial"] = deepcopy(patterning.get_protocol_from_stages(fiducial_stage))
+        lamella.protocol["fiducial"]["point"] = fiducial_stage.pattern.point.to_dict()
+        lamella.fiducial_area, _  = _calculate_fiducial_area_v2(ib_image, 
+            deepcopy(fiducial_stage.pattern.point), 
+            lamella.protocol["fiducial"]["stages"][0]["height"])
+        alignment_hfw = fiducial_stage.milling.hfw
 
-    # mill the fiducial
-    if use_fiducial:
+        # mill the fiducial
         fiducial_stage = patterning.get_milling_stages("fiducial", lamella.protocol, Point.from_dict(lamella.protocol["fiducial"]["point"]))
         stages = update_milling_ui(fiducial_stage, parent_ui, 
             msg=f"Press Run Milling to mill the fiducial for {lamella._petname}. Press Continue when done.", 
             validate=validate)
         alignment_hfw = stages[0].milling.hfw
+    else:
+        # non-fiducial based alignment
+        alignment_area_dict = settings.protocol["options"].get("alignment_area", DEFAULT_ALIGNMENT_AREA)
+        lamella.fiducial_area = FibsemRectangle.from_dict(alignment_area_dict)
+        alignment_hfw = lamella.protocol["lamella"]["stages"][0]["hfw"]
+
+    logging.info(f"ALIGNMENT AREA WORKFLOW: {lamella.fiducial_area}")
+    lamella.fiducial_area = update_alignment_area_ui(alignment_area=lamella.fiducial_area, 
+                                              parent_ui=parent_ui, 
+                                              msg="Edit Alignment Area. Press Continue when done.", 
+                                              validate=validate )
 
     # set reduced area for fiducial alignment
     settings.image.reduced_area = lamella.fiducial_area
-    print(f"REDUCED_AREA: ", lamella.fiducial_area)
+    logging.info(f"Alignment: Use Fiducial: {use_fiducial}, Alignment Area: {lamella.fiducial_area}")
 
-    # TODO: the ref should also be acquired at the milling current?
+    # TODO: the ref should also be acquired at the milling current? -> yes
     # for alignment
     settings.image.beam_type = BeamType.ION
     settings.image.save = True
-    settings.image.hfw =  alignment_hfw #fcfg.REFERENCE_HFW_SUPER
+    settings.image.hfw =  alignment_hfw
     settings.image.filename = f"ref_alignment"
     settings.image.autocontrast = False # disable autocontrast for alignment
-    print(f"REDUCED_AREA: ", settings.image.reduced_area)
+    logging.info(f"REDUCED_AREA: {settings.image.reduced_area}")
     ib_image = acquire.new_image(microscope, settings.image)
     settings.image.reduced_area = None
     settings.image.autocontrast = True

--- a/autolamella/workflows/ui.py
+++ b/autolamella/workflows/ui.py
@@ -5,6 +5,7 @@ from fibsem.patterning import FibsemMillingStage
 from fibsem.structures import (
     FibsemStagePosition,
     FibsemImage,
+    FibsemRectangle,
 )
 import time
 
@@ -220,3 +221,57 @@ def ask_user_continue_workflow(parent_ui, msg: str = "Continue with the next sta
     if validate:
         ret = ask_user(parent_ui=parent_ui, msg=msg, pos="Continue", neg="Exit")
     return ret
+
+def update_alignment_area_ui(alignment_area: FibsemRectangle, parent_ui: AutoLamellaUI, 
+        msg: str = "Edit Alignment Area", validate: bool = True) -> FibsemRectangle:
+    """ Update the alignment area in the UI and return the updated alignment area."""
+    _check_for_abort(parent_ui, msg = f"Workflow aborted by user.")
+
+    if not validate:
+        return alignment_area
+
+    INFO = {
+        "msg": msg,
+        "pos": "Continue",
+        "neg": None,
+        "det": None,
+        "eb_image": None,
+        "ib_image": None,
+        "movement": None,
+        "mill": None,
+        "alignment_area": alignment_area,
+    }
+    parent_ui.ui_signal.emit(INFO)
+
+    parent_ui.WAITING_FOR_USER_INTERACTION = True
+    logging.info("WAITING_FOR_USER_INTERACTION...")
+    while parent_ui.WAITING_FOR_USER_INTERACTION:
+        time.sleep(1)
+
+    _check_for_abort(parent_ui, msg = f"Workflow aborted by user.")
+
+    INFO = {
+        "msg": "Updating Milling Stages",
+        "pos": None,
+        "neg": None,
+        "det": None,
+        "eb_image": None,
+        "ib_image": None,
+        "movement": None,
+        "mill": None,
+        "stages": None,
+        "alignment_area": "clear",
+    }
+
+    parent_ui.WAITING_FOR_UI_UPDATE = True
+    parent_ui.ui_signal.emit(INFO)
+    logging.info(f"WAITING FOR UI UPDATE... ")
+    while parent_ui.WAITING_FOR_UI_UPDATE:
+        time.sleep(0.5)
+
+    # retrieve the updated alignment area
+    alignment_area = deepcopy(parent_ui.image_widget.get_alignment_area())
+
+    return alignment_area
+
+


### PR DESCRIPTION
Allow users to use non-fiducial based alignment in setup lamella.

Features:
- [x] Enable toggling use_fiducial in user interface
- [x] Enable editing the alignment area in the user interface
- [x] Load default fiducial values if not specified in protocol
- [x] Define alignment area in protocol: protocol["options"]["alignment_area"] 